### PR TITLE
Xyifer_ClassicSteam.yaml remove non working screenshots

### DIFF
--- a/addons/themes_desktop/Xyifer_ClassicSteam.yaml
+++ b/addons/themes_desktop/Xyifer_ClassicSteam.yaml
@@ -11,7 +11,3 @@ SourceUrl: https://gitlab.com/xyifer12/ClassicSteam-Playnite-Theme
 Links:
     GitLab: https://gitlab.com/xyifer12/ClassicSteam-Playnite-Theme
     Playnite Forum: https://playnite.link/forum/thread-299-post-922.html
-Screenshots:
-    - Image: https://gitlab.com/xyifer12/ClassicSteam-Playnite-Theme/-/raw/master/img/Img1.png
-    - Image: https://gitlab.com/xyifer12/ClassicSteam-Playnite-Theme/-/raw/master/img/Img2.png
-    - Image: https://gitlab.com/xyifer12/ClassicSteam-Playnite-Theme/-/raw/master/img/Img3.png


### PR DESCRIPTION
Repository is in https://gitlab.com/xyifer12/ClassicSteam-Playnite-Theme but doesn't even have thumbnails for someone else to fix it. A lot of time has passed but the dev has not fixed it so I think they should be removed altogether

Will fix the non working screenshots in the addons page 

![image](https://user-images.githubusercontent.com/1389286/146297492-e8852438-bdc6-4132-9848-57562a02e4c7.png)
