### PR TITLE
Fixing AddoinId from the Emulation Toolbox extension

### DIFF
--- a/addons/generic/Ferrell_EmulationToolbox.yaml
+++ b/addons/generic/Ferrell_EmulationToolbox.yaml
@@ -1,4 +1,4 @@
-AddonId: playnite-emulation-toolbox-plugin
+AddonId: EmulationToolbox_eb3ccf5d-971a-41a6-aefd-aae9455e6de4
 Name: Emulation Toolbox
 Type: Generic
 Author: Ferrell


### PR DESCRIPTION
I've added my extension with the wrong AddonId before, so it wasn't showing to update it in the database.