### PR TITLE
Fix link typo in Lacro59_IsThereAnyDeal.yaml

### DIFF
--- a/addons/generic/Lacro59_IsThereAnyDeal.yaml
+++ b/addons/generic/Lacro59_IsThereAnyDeal.yaml
@@ -19,7 +19,7 @@ Description: |-
     * notification for new giveaways 
 Tags: ["Store", "Giveaways", "Price"]
 Links:
-    Forum: ttps://playnite.link/forum/thread-323.html
+    Forum: https://playnite.link/forum/thread-323.html
     GitHub: https://github.com/Lacro59/playnite-isthereanydeal-plugin
     Translate: https://crowdin.com/project/playnite-extensions
 IconUrl: https://raw.githubusercontent.com/Lacro59/playnite-isthereanydeal-plugin/master/source/icon.png


### PR DESCRIPTION
This is not my extension, but it's a pretty evident typo that makes the link unusable.