### PR TITLE
Changes location of manifest.yml for PSN library plugin

### DIFF
--- a/addons/library/Xenor_PlayStationLibrary.yaml
+++ b/addons/library/Xenor_PlayStationLibrary.yaml
@@ -1,7 +1,7 @@
 AddonId: PlayStationLibrary_Builtin
 IconUrl: https://raw.githubusercontent.com/XenorPLxx/playnite-library-psn/main/source/Libraries/PSNLibrary/icon.png
 Type: GameLibrary
-InstallerManifestUrl: https://raw.githubusercontent.com/XenorPLxx/playnite-library-psn/main/manifests/PlayStationLibrary_Builtin.yaml
+InstallerManifestUrl: https://raw.githubusercontent.com/XenorPLxx/playnite-library-psn/main/manifest.yaml
 ShortDescription: Imports games from PSN account.
 Name: PlayStation library integration
 Author: Xenor


### PR DESCRIPTION
I've finished the first part of the PSN library refactor, which moved stuff around, including the manifest.yml file.