### PR TITLE
Create odeyity_SteamUpdate.yaml

### DIFF
--- a/addons/generic/odeyity_SteamUpdate.yaml
+++ b/addons/generic/odeyity_SteamUpdate.yaml
@@ -1,15 +1,24 @@
 AddonId: SteamUpdate_e9ecfc93-b000-4439-8dd8-a52b7b887a43
-Name: Steam Update
 Type: Generic
+Name: Steam Update
 Author: odeyity
 ShortDescription: Notifies you of any updates for a Steam game.
 InstallerManifestUrl: https://raw.githubusercontent.com/odeyity/Playnite-Steam-Update-Plugin/main/manifest.yaml
-SourceUrl: https://github.com/odeyity/Playnite-Steam-Update-Plugin/
-Description: On Playnite startup, this C# plugin simply opens a python script compiled into an executable that reads appmanifest data for Steam and alerts the user of any games that have updates.
+SourceUrl: https://github.com/odeyity/Playnite-Steam-Update-Plugin
+Description: |-
+    Info:
+    * On Playnite startup, this C# plugin simply opens a python script compiled into an executable that reads appmanifest data for Steam and alerts the user of any games that have updates.
+    
+    What this plugin requires:
+    * Steamapps folder location
+    
+
+
 Tags: ["Generic", "Steam", "Updates"]
 Links:
-    GitHub page: https://github.com/odeyity/Playnite-Steam-Update-Plugin
+    GitHub: https://github.com/odeyity/Playnite-Steam-Update-Plugin
+
+IconUrl: https://raw.githubusercontent.com/odeyity/Playnite-Steam-Update-Plugin/main/icon.png
 Screenshots:
-    Python Window: https://raw.githubusercontent.com/odeyity/Playnite-Steam-Update-Plugin/main/screenshots/alert.png
-    
-IconUrl: https://github.com/odeyity/Playnite-Steam-Update-Plugin/raw/main/icon.png
+    - Thumbnail: https://raw.githubusercontent.com/odeyity/Playnite-Steam-Update-Plugin/main/screenshots/main_thumb.png
+      Image: https://raw.githubusercontent.com/odeyity/Playnite-Steam-Update-Plugin/main/screenshots/main_full.png

--- a/addons/generic/odeyity_SteamUpdate.yaml
+++ b/addons/generic/odeyity_SteamUpdate.yaml
@@ -1,0 +1,15 @@
+AddonId: SteamUpdate_e9ecfc93-b000-4439-8dd8-a52b7b887a43
+Name: Steam Update
+Type: Generic
+Author: odeyity
+ShortDescription: Notifies you of any updates for a Steam game.
+InstallerManifestUrl: https://raw.githubusercontent.com/odeyity/Playnite-Steam-Update-Plugin/main/manifest.yaml
+SourceUrl: https://github.com/odeyity/Playnite-Steam-Update-Plugin/
+Description: On Playnite startup, this C# plugin simply opens a python script compiled into an executable that reads appmanifest data for Steam and alerts the user of any games that have updates.
+Tags: ["Generic", "Steam", "Updates"]
+Links:
+    GitHub page: https://github.com/odeyity/Playnite-Steam-Update-Plugin
+Screenshots:
+    Python Window: https://raw.githubusercontent.com/odeyity/Playnite-Steam-Update-Plugin/main/screenshots/alert.png
+    
+IconUrl: https://github.com/odeyity/Playnite-Steam-Update-Plugin/raw/main/icon.png


### PR DESCRIPTION
The plugin is badly written but does work. It reads app manifest data from the steamapps directory and displays what games have an update in a python window that opens on Playnite startup. Literally all the C# Plugin does is open the compiled python executable.

The reason that the API version required is 0 is because the plugin doesn't need to use the Playnite API. I know the way I've done it is really lazy and looks ugly if anything. I will one day implement it into native Playnite as a display but I thought I would release now like this with a Python executable. If I should change the value from 0 or if it is too bad to be published please let me know and how I can improve.