### PR TITLE
LauncherMenus Plugin

### DIFF
--- a/addons/generic/odeyity_LauncherMenus.yaml
+++ b/addons/generic/odeyity_LauncherMenus.yaml
@@ -1,0 +1,26 @@
+AddonId: LauncherMenus_626f6c31-eac9-421b-bd20-82381da4dde8
+Type: Generic
+Name: Launcher Menus
+Author: odeyity
+ShortDescription: Adds buttons to access Steam/Epic Menus.
+InstallerManifestUrl: https://raw.githubusercontent.com/odeyity/Playnite-LauncherMenus-Plugin/main/manifest.yaml
+SourceUrl: https://github.com/odeyity/Playnite-LauncherMenus-Plugin
+Description: |-
+    Info:
+    * A C# plugin that simply adds top panel buttons to access the Steam and Epic Games menus
+    
+    What this plugin requires:
+    * Login to Steam and/or Epic Games
+
+    How to setup:
+    * Click the top panel buttons and login if needed
+
+
+Tags: ["Generic", "Steam", "Epic", "Menu", "Web"]
+Links:
+    GitHub: https://github.com/odeyity/Playnite-LauncherMenus-Plugin
+
+IconUrl: https://raw.githubusercontent.com/odeyity/Playnite-LauncherMenus-Plugin/main/icon.png
+Screenshots:
+    - Thumbnail: https://raw.githubusercontent.com/odeyity/Playnite-LauncherMenus-Plugin/main/screenshots/main_thumb.png
+      Image: https://raw.githubusercontent.com/odeyity/Playnite-LauncherMenus-Plugin/main/screenshots/main_full.png


### PR DESCRIPTION
Verified yamls to work

This plugin adds a Steam button and Epic Games button to the top panel which both open web pages to their respective sites,

I made this so I could easily access things like the stores of Steam and Epic and the workshop etc.