### PR TITLE
Create roob-p_AutoCategories.yaml

### DIFF
--- a/addons/generic/roob-p_AutoCategories.yaml
+++ b/addons/generic/roob-p_AutoCategories.yaml
@@ -1,0 +1,15 @@
+AddonId: AutoCategories
+Type: Generic
+Name: AutoCategories
+Author: roob-p
+ShortDescription: Automatic platform/source categories to games with custom names.  
+InstallerManifestUrl: https://raw.githubusercontent.com/roob-p/AutoCategories-PlayniteExtension/main/manifest.yaml
+SourceUrl: https://github.com/roob-p/AutoCategories-PlayniteExtension
+Description: This extension will automatically add, create and apply "platform/source" categories to your games, making easy to organize your library especially after importing new games.
+             *You can specify short game's platform names for the categories (for example Nintento Entertainment System -> Nintendo NES, Sony Playstation 2 -> Sony PS2, etc).
+             *You can also add sources like Ea App, Ubisoft Connect and add short names (like Origin, Uplay) or whatever you want. Edit Platforms.txt and Source.txt as you like without having to reload the extension.
+Tags: ["Generic", "Categories", "Organize", "Platforms", "Source", "Shortnames", "Custom names"]
+Links: 
+     Github: https://github.com/roob-p/AutoCategories-PlayniteExtension/
+     Donate: https://ko-fi/roobp
+IconUrl: https://raw.githubusercontent.com/roob-p/AutoCategories-PlayniteExtension/main/icon.jpg


### PR DESCRIPTION
This extension will automatically add, create and apply "platform/source" categories to your games, making easy to organize your library especially after importing new games. You can specify short game's platform names for the categories (for example Nintento Entertainment System -> Nintendo NES, Sony Playstation 2 -> Sony PS2, etc). You can also add sources like Ea App, Ubisoft Connect and add short names (like Origin, Uplay) or whatever you want. Edit Platforms.txt and Source.txt as you like without having to reload.