### PR TITLE
Add Friendly Set Play Time

### DIFF
--- a/addons/generic/CanRanBan_Generic_FriendlySetPlayTime.yaml
+++ b/addons/generic/CanRanBan_Generic_FriendlySetPlayTime.yaml
@@ -1,0 +1,15 @@
+AddonId: CanRanBan_Generic_FriendlySetPlayTime
+Type: Generic
+IconUrl: https://raw.githubusercontent.com/CanRanBan/PlayniteExtensionFork-FriendlySetPlayTime/main/Source/Resources/FriendlySetPlayTimeIcon.ico
+Name: Friendly Set Play Time
+ShortDescription: Adds an item in the more menu of games to simplify the input of play time values.
+Author: CanRanBan (Original version by erys)
+SourceUrl: https://github.com/CanRanBan/PlayniteExtensionFork-FriendlySetPlayTime
+Links:
+    GitHub (Source code): https://github.com/CanRanBan/PlayniteExtensionFork-FriendlySetPlayTime
+    Wiki (Introduction and Help): https://github.com/CanRanBan/PlayniteExtensionFork-FriendlySetPlayTime/wiki
+    Playnite Discord (#extensions-support): https://discord.com/channels/365863063296933888/808419165311467630
+    Issues (Feature requests and Bugs): https://github.com/CanRanBan/PlayniteExtensionFork-FriendlySetPlayTime/issues
+InstallerManifestUrl: https://raw.githubusercontent.com/CanRanBan/PlayniteExtensionFork-FriendlySetPlayTime/main/Manifests/PackageInstaller/CanRanBan_Generic_FriendlySetPlayTime.yaml
+Description: The "Friendly Set Play Time" Playnite extension adds an item in the more menu of games to simplify the input of play time values. The possibility to input minutes, hours and days besides the default input of seconds is added.
+Tags: ["CanRanBan", "Friendly", "Set", "Play", "Time", "Simplify", "Input", "Menu", "Item", "Days", "Hours", "Minutes", "Seconds"]


### PR DESCRIPTION
This version of Friendly Set Play Time is a major rewrite of the previous version fixing longstanding issues of the original extension and adding a few usability improvements.

It uses a separate extension ID / GUID.