### PR TITLE
Add GameSpectrum generic plugin

### DIFF
--- a/addons/generic/game-scrobbler_gs-playnite.yaml
+++ b/addons/generic/game-scrobbler_gs-playnite.yaml
@@ -1,0 +1,10 @@
+AddonId: 32975fed-6915-4dd3-a230-030cdc5265ae
+Name: Game Spectrum
+ShortDescription: Visualize Your Playnite Stats
+Author: GameScrobbler
+Type: Generic
+Tags: ['Report', 'Statistics']
+SourceUrl: https://github.com/game-scrobbler/gs-playnite
+InstallerManifestUrl: https://raw.githubusercontent.com/game-scrobbler/gs-playnite/main/installer_manifest.yaml
+IconUrl: https://raw.githubusercontent.com/game-scrobbler/gs-playnite/main/icon.png
+Description: Game Spectrum (GS), a new plugin designed to bring your Playnite stats to life with stunning visuals and interactive insights. 🎮✨


### PR DESCRIPTION
Verified it with ToolBox:

```
> .\Toolbox.exe verify addon https://raw.githubusercontent.com/game-scrobbler/gs-playnite/main/manifest.yaml
Verifying addon manifest https://raw.githubusercontent.com/game-scrobbler/gs-playnite/main/manifest.yaml ...
Verifying installer manifest https://raw.githubusercontent.com/game-scrobbler/gs-playnite/main/installer_manifest.yaml ...
Installer manifest passed verification.
Addon manifest passed verifiction.
```

Also I have a question, we are still actively developing this plugin, just appending the new versions to the installer manifest is enough for it to get updated? 