### PR TITLE
Add Autogrid and GameHoverDetails

### DIFF
--- a/addons/generic/danitesler_autogrid.yaml
+++ b/addons/generic/danitesler_autogrid.yaml
@@ -1,0 +1,18 @@
+AddonId: Autogrid_7F3E9B82
+Type: Generic
+Name: Autogrid
+Author: danitesler
+ShortDescription: Tight Desktop Grid with stable columns—auto-adjusts cover width on resize.
+InstallerManifestUrl: https://raw.githubusercontent.com/danitesler/playnite-extensions/main/src/Autogrid/info/InstallerManifest.yaml
+SourceUrl: https://github.com/danitesler/playnite-extensions/tree/main/src/Autogrid
+Description: |
+  Autogrid keeps your Playnite Desktop Grid visually tight and easy to scan: you can pull covers together so the grid reads as a continuous wall of art, with far less empty gutter between tiles than the default layout.
+
+  Set a target column count once. When you resize the window, the extension adjusts cover width so that column count stays stable and the grid does not constantly reflow.
+
+  Includes optional viewport adjustment for theme gutters and debug measurement logging for troubleshooting.
+Tags: [Desktop, Grid, Layout, Generic, UI]
+IconUrl: https://raw.githubusercontent.com/danitesler/playnite-extensions/main/src/Autogrid/info/icon.png
+Links:
+  Plugin homepage: https://github.com/danitesler/playnite-extensions/tree/main/src/Autogrid
+  Report issue: https://github.com/danitesler/playnite-extensions/issues

--- a/addons/generic/danitesler_gamehoverdetails.yaml
+++ b/addons/generic/danitesler_gamehoverdetails.yaml
@@ -1,0 +1,15 @@
+﻿AddonId: GameHoverDetails_BA249C5D
+Type: Generic
+Name: GameHoverDetails
+Author: danitesler
+ShortDescription: Peek game info on hover—resize the card and choose what it shows.
+InstallerManifestUrl: https://raw.githubusercontent.com/danitesler/playnite-extensions/main/src/GameHoverDetails/info/InstallerManifest.yaml
+SourceUrl: https://github.com/danitesler/playnite-extensions/tree/main/src/GameHoverDetails
+Description: |
+  Pause on a cover to skim the essentials without opening each game.
+  Pick how wide the card is and up to five lines of info—the same kinds of facts Playnite already shows for a game.
+  Arrange and reorder them so your hover matches how you browse.
+Tags: [Desktop, Hover, Details, Tooltip, Generic]
+IconUrl: https://raw.githubusercontent.com/danitesler/playnite-extensions/main/src/GameHoverDetails/info/icon.png
+Links:
+  Plugin homepage: https://github.com/danitesler/playnite-extensions/tree/main/src/GameHoverDetails


### PR DESCRIPTION
## Add-ons

Two **Generic** extensions from [danitesler/playnite-extensions](https://github.com/danitesler/playnite-extensions):

| AddonId | Manifest (source repo) |
|--------|-------------------------|
| \Autogrid_7F3E9B82\ | Installer: raw \InstallerManifest.yaml\ on \main\ |
| \GameHoverDetails_BA249C5D\ | Same |

- **Installer manifests** (referenced by \InstallerManifestUrl\): hosted on default branch as required by the [addon manifest](https://github.com/JosefNemec/PlayniteAddonDatabase#Addon-manifest) docs.
- **\.pext\** URLs in those installer manifests point at GitHub Releases on the source repo (per-extension tags).

Please review when convenient. Thank you!

Made with [Cursor](https://cursor.com)