### PR TITLE
Add ErogameScape Metadata addon

### DIFF
--- a/addons/metadata/minuspiral_ErogameScapeMetadata.yaml
+++ b/addons/metadata/minuspiral_ErogameScapeMetadata.yaml
@@ -1,0 +1,28 @@
+AddonId: ErogameScapeMetadata_b8e3f2a1-5c4d-4e6f-9a1b-2d3e4f5a6b7c
+Type: MetadataProvider
+Name: ErogameScape Metadata
+Author: minuspiral
+ShortDescription: Imports game metadata from ErogameScape for Japanese visual novels / eroge.
+Description: |-
+    Fetches metadata for Japanese visual novels and eroge from ErogameScape (批評空間),
+    with fallbacks to DLsite, Getchu, VNDB, and DMM for richer information.
+
+    Supported fields:
+    * Name / Furigana
+    * Developer / Publisher (brand)
+    * Release date
+    * Community score (ErogameScape median)
+    * Cover image (VNDB portrait preferred, DMM fallback)
+    * Background image (VNDB SFW screenshots)
+    * Description (DLsite / Getchu / VNDB fallback chain)
+    * Genres (DLsite / ErogameScape)
+    * Tags (POV data)
+    * Series (game group)
+    * Features (attributes)
+    * Links (ErogameScape, official site, DLsite, DMM)
+InstallerManifestUrl: https://raw.githubusercontent.com/minuspiral/playnite-with-erogamescape/main/installer.yaml
+SourceUrl: https://github.com/minuspiral/playnite-with-erogamescape
+IconUrl: https://raw.githubusercontent.com/minuspiral/playnite-with-erogamescape/main/icon.png
+Tags: ['Metadata', 'Visual Novel', 'Eroge', 'ErogameScape', 'Japanese']
+Links:
+    GitHub: https://github.com/minuspiral/playnite-with-erogamescape


### PR DESCRIPTION
## Addon

- **Name:** ErogameScape Metadata
- **Type:** MetadataProvider
- **Author:** minuspiral
- **Source:** https://github.com/minuspiral/playnite-with-erogamescape
- **Latest release:** [v1.0.1](https://github.com/minuspiral/playnite-with-erogamescape/releases/tag/v1.0.1)

## Description

Metadata provider for Japanese visual novels / eroge. Fetches data from [ErogameScape](https://erogamescape.dyndns.org/) (批評空間), with DLsite / Getchu / VNDB / DMM as fallback sources for descriptions and images.

## Supported fields

Name, furigana, developer, publisher (brand), release date, community score (ErogameScape median), cover image (VNDB portrait preferred / DMM fallback), background image (VNDB SFW screenshots), description (DLsite / Getchu / VNDB fallback chain), genres, tags (POV data), series, features, links.

## Manifests

- Addon manifest (this PR): `addons/metadata/minuspiral_ErogameScapeMetadata.yaml`
- Installer manifest: https://raw.githubusercontent.com/minuspiral/playnite-with-erogamescape/main/installer.yaml