### PR TITLE
Add Penumbra Night, Dawn and Blur themes

### DIFF
--- a/addons/themes_desktop/gOOvER_Penumbra_Dawn_Theme.yaml
+++ b/addons/themes_desktop/gOOvER_Penumbra_Dawn_Theme.yaml
@@ -1,0 +1,34 @@
+AddonId: Penumbra_Dawn_Theme
+Type: ThemeDesktop
+Name: Penumbra Dawn
+Author: gOOvER
+ShortDescription: Dark desktop theme with warm accents, animations and extensive extension support.
+InstallerManifestUrl: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/InstallerManifest/Penumbra_Dawn_Theme.yaml
+SourceUrl: https://github.com/gOOvER/Penumbra-Themes
+Tags: ["dark", "penumbra", "dawn", "animated", "duplicatehider", "themeextras", "extensions", "backgroundchanger", "gameactivity", "successstory"]
+Links:
+    GitHub: https://github.com/gOOvER/Penumbra-Themes
+IconUrl: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/source/PenumbraDawn/Images/applogo.png
+Screenshots:
+    - Thumbnail: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/Screenshot_Dawn_Details_Thumb.jpg
+      Image: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/Screenshot_Dawn_Details.jpg
+    - Thumbnail: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/Screenshot_Dawn_Grid_Thumb.jpg
+      Image: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/Screenshot_Dawn_Grid.jpg
+Description: |-
+    Dark desktop theme with warm accents, smooth animations and a compact filter panel.
+    Floating action buttons in the details view and extensive plugin integration.
+
+    Supported extension integrations:
+    - ThemeExtras (Library Banners, platform banners, animated controls)
+    - DuplicateHider
+    - ExtraMetadataLoader (logo + video)
+    - SuccessStory
+    - BackgroundChanger (custom background + cover image)
+    - HowLongToBeat
+    - GameActivity
+    - CheckDLC
+    - ScreenshotsVisualizer
+    - ReviewViewer
+    - NewsViewer
+    - ThemeModifier
+    - ThemesDetailsViewToGridViewConverter

--- a/addons/themes_desktop/gOOvER_Penumbra_Night_Theme.yaml
+++ b/addons/themes_desktop/gOOvER_Penumbra_Night_Theme.yaml
@@ -1,0 +1,33 @@
+AddonId: Penumbra_Night_Theme
+Type: ThemeDesktop
+Name: Penumbra Night
+Author: gOOvER
+ShortDescription: Dark desktop theme with noise texture, teal accents, smooth animations and extensive extension support.
+InstallerManifestUrl: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/InstallerManifest/Penumbra_Night_Theme.yaml
+SourceUrl: https://github.com/gOOvER/Penumbra-Themes
+Tags: ["dark", "penumbra", "night", "teal", "animated", "duplicatehider", "themeextras", "extensions", "backgroundchanger", "gameactivity", "successstory"]
+Links:
+    GitHub: https://github.com/gOOvER/Penumbra-Themes
+IconUrl: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/source/PenumbraNight/Images/applogo.png
+Screenshots:
+    - Thumbnail: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/Screenshot_Night_Thumb.png
+      Image: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/Screenshot_Night.png
+    - Thumbnail: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/Screenshot_Night_Grid_Thumb.jpg
+      Image: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/Screenshot_Night_Grid.png
+Description: |-
+    Dark desktop theme with noise texture, teal accents and smooth animations.
+    Compact filter panel and floating action buttons in the details view.
+
+    Supported extension integrations:
+    - ThemeExtras (Library Banners, platform banners, animated controls)
+    - DuplicateHider
+    - ExtraMetadataLoader (logo + video)
+    - SuccessStory
+    - BackgroundChanger (custom background + cover image)
+    - HowLongToBeat
+    - GameActivity
+    - CheckDLC
+    - ScreenshotsVisualizer
+    - ReviewViewer
+    - NewsViewer
+    - ThemesDetailsViewToGridViewConverter

--- a/addons/themes_fullscreen/gOOvER_Penumbra_Blur_Theme.yaml
+++ b/addons/themes_fullscreen/gOOvER_Penumbra_Blur_Theme.yaml
@@ -1,0 +1,24 @@
+AddonId: Penumbra_Blur_Theme
+Type: ThemeFullscreen
+Name: Penumbra Blur
+Author: gOOvER
+ShortDescription: Dark fullscreen theme with blur effects, noise texture, teal accents and extension support.
+InstallerManifestUrl: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/InstallerManifest/Penumbra_Blur_Theme.yaml
+SourceUrl: https://github.com/gOOvER/Penumbra-Themes
+Tags: ["dark", "penumbra", "blur", "fullscreen", "teal", "duplicatehider", "thememodifier", "extrametadataloader"]
+Links:
+    GitHub: https://github.com/gOOvER/Penumbra-Themes
+IconUrl: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/source/PenumbraBlur/Images/applogo.png
+Screenshots:
+    - Thumbnail: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/Screenshot_Blur_Main_Thumb.png
+      Image: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/Screenshot_Blur_Main.png
+    - Thumbnail: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/Screenshot_Blur_Main_Thumb.png
+      Image: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/Screenshot_Blur_Detail.png
+Description: |-
+    Dark fullscreen theme with blur effects, noise texture and teal accents.
+    Designed for controller and couch-gaming use.
+
+    Supported extension integrations:
+    - DuplicateHider
+    - ExtraMetadataLoader (logo + video)
+    - ThemeModifier (configurable blur, colors, grid corner radius)

--- a/addons/themes_fullscreen/gOOvER_Penumbra_Blur_Theme.yaml
+++ b/addons/themes_fullscreen/gOOvER_Penumbra_Blur_Theme.yaml
@@ -12,7 +12,7 @@ IconUrl: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/source/Pe
 Screenshots:
     - Thumbnail: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/Screenshot_Blur_Main_Thumb.png
       Image: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/Screenshot_Blur_Main.png
-    - Thumbnail: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/Screenshot_Blur_Main_Thumb.png
+    - Thumbnail: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/Screenshot_Blur_Detail.png
       Image: https://raw.githubusercontent.com/gOOvER/Penumbra-Themes/main/Screenshot_Blur_Detail.png
 Description: |-
     Dark fullscreen theme with blur effects, noise texture and teal accents.


### PR DESCRIPTION
## New themes — Fork of DH_Themes by felixkmh

These themes are a fork of the original [DH_Themes](https://github.com/felixkmh/DH_Themes) by [@felixkmh](https://github.com/felixkmh).
I have been using these themes for years and love them, but as there have been no updates for a long time, I decided to fork and continue maintaining them under the name **Penumbra Themes**.

Changes compared to the original:
- Updated to ThemeApiVersion 2.9.0
- Added support for additional plugins (BackgroundChanger, GameActivity, CheckDLC, ScreenshotsVisualizer, ReviewViewer)
- Added themeExtras.yaml, thememodifier.yaml support
- Added AgeRating images (ESRB/PEGI/RARS), platform images, Library Banners
- Added custom video controls (Night theme)

### Penumbra Night (Desktop)
- **AddonId:** Penumbra_Night_Theme
- Dark theme with noise texture, teal accents and smooth animations
- Plugin support: ThemeExtras, DuplicateHider, ExtraMetadataLoader, SuccessStory, BackgroundChanger, HowLongToBeat, GameActivity, CheckDLC, ScreenshotsVisualizer, ReviewViewer, NewsViewer

### Penumbra Dawn (Desktop)
- **AddonId:** Penumbra_Dawn_Theme
- Dark theme with warm accents, animations and compact filter panel
- Plugin support: ThemeExtras, DuplicateHider, ExtraMetadataLoader, SuccessStory, BackgroundChanger, HowLongToBeat, GameActivity, CheckDLC, ScreenshotsVisualizer, ReviewViewer, ThemeModifier

### Penumbra Blur (Fullscreen)
- **AddonId:** Penumbra_Blur_Theme
- Dark fullscreen theme with blur effects and teal accents
- Plugin support: DuplicateHider, ExtraMetadataLoader, ThemeModifier

Source: https://github.com/gOOvER/Penumbra-Themes
Original: https://github.com/felixkmh/DH_Themes