### PR TITLE
Update RandomSorting metadata for 1.3

### DIFF
--- a/addons/generic/mjd4219_RandomSorting.yaml
+++ b/addons/generic/mjd4219_RandomSorting.yaml
@@ -2,8 +2,8 @@ AddonId: mjd4219_RandomSorting_Plugin
 IconUrl: https://raw.githubusercontent.com/mjd4219/RandomSorting_playnite/master/source/icon.png
 Type: Generic
 InstallerManifestUrl: https://raw.githubusercontent.com/mjd4219/RandomSorting_playnite/master/InstallerManifest/mjd4219_RandomSorting_Plugin.yaml
-ShortDescription: Generates random identifiers to allow game lists to be sorted randomly. 
-Description: Playnite plugin to allow lists to be sorted in a random order. It works by generating a random number for each non-hidden game in your library, and assigning this number as either a Category or a Tag (uses Categories by default). You can then order your list by Category (or by Tag, depending on your configuration), and the list will be sorted in a random order. The plugin can be configured to run each time playnite starts, and/or each time a game is started. Warning- this plugin generates an individual Category or Tag for each game in your library, which can make it difficult to browse your existing Tags or Categories. To clean up any Tags or Categories created by the plugin, disable the plugin and use Library Manager. 
+ShortDescription: Generates random Tags or Categories so game lists can be sorted randomly.
+Description: Playnite plugin to sort game lists in a random order by assigning generated Tags or Categories to eligible games. It supports manual, startup, and game-start randomization; optional Playnite Feature filtering; collision-free rank labels; configurable automatic run behavior; hidden and uninstalled game inclusion settings; safe cleanup of unused plugin-created labels; and performance settings for larger libraries. Automatic runs are chunked to reduce UI stalls, while manual assignment and cleanup show cancellable progress dialogs.
 Name: RandomSorting
 Author: mjd4219
 Links:


### PR DESCRIPTION
Updates the RandomSorting add-on browser metadata for the 1.3 release.

Release: https://github.com/mjd4219/RandomSorting_playnite/releases/tag/1.3
Installer manifest: https://raw.githubusercontent.com/mjd4219/RandomSorting_playnite/master/InstallerManifest/mjd4219_RandomSorting_Plugin.yaml

Changes:
- Refreshes the add-on description for Feature filtering, collision-free labels, automatic run behavior, safe cleanup, hidden/uninstalled game inclusion settings, and larger-library performance options.
- Keeps the existing add-on ID and installer manifest URL.

Validation:
- Playnite Toolbox verify Addon passed for addons/generic/mjd4219_RandomSorting.yaml.
- Playnite Toolbox verify Installer passed for the RandomSorting installer manifest.