### PR TITLE
Import Nintendo Switch / Switch 2 games and playtime from Exophase in…

### DIFF
--- a/addons/generic/NintendoExophaseImporter.yaml
+++ b/addons/generic/NintendoExophaseImporter.yaml
@@ -1,0 +1,15 @@
+AddonId: NintendoExophaseImporter
+Type: Generic
+Name: Nintendo Exophase Importer
+Author: Tisma
+ShortDescription: Import Nintendo Switch / Switch 2 games and playtime from Exophase into Playnite.
+InstallerManifestUrl: https://raw.githubusercontent.com/MatisAgr/Nintendo-Exophase-Importer/main/manifests/installer.yaml
+SourceUrl: https://github.com/MatisAgr/Nintendo-Exophase-Importer
+Links:
+  Tisma Website: https://tisma.dev
+  Tisma GitHub: https://github.com/MatisAgr/
+Description: |
+  Pulls the playtime of your Nintendo Switch and Switch 2 games from your Exophase profile
+  and writes it into Playnite.
+Tags: ["switch", "nintendo", "playtime", "exophase", "sync"]
+IconUrl: https://raw.githubusercontent.com/MatisAgr/Nintendo-Exophase-Importer/main/icon.png

--- a/addons/library/NintendoExophaseImporter.yaml
+++ b/addons/library/NintendoExophaseImporter.yaml
@@ -1,5 +1,5 @@
 AddonId: NintendoExophaseImporter
-Type: Generic
+Type: GameLibrary
 Name: Nintendo Exophase Importer
 Author: Tisma
 ShortDescription: Import Nintendo Switch / Switch 2 games and playtime from Exophase into Playnite.


### PR DESCRIPTION
Pulls the playtime of your Nintendo Switch and Switch 2 games from your Exophase profile and writes it into Playnite.

<img width="1362" height="1032" alt="image" src="https://github.com/user-attachments/assets/9632d445-801d-4912-b63f-6b8d2cf3a98b" />

<img width="1362" height="1032" alt="image" src="https://github.com/user-attachments/assets/02f6bd99-eb67-4cbe-81fa-1c64dbf35d4b" />
