### PR TITLE
Add Audio Switcher generic extension

### DIFF
--- a/addons/generic/Narian_AudioSwitcher.yaml
+++ b/addons/generic/Narian_AudioSwitcher.yaml
@@ -1,0 +1,13 @@
+AddonId: PlayniteAudioSwitcher_708b6ec4-bf96-4c0d-bd9d-fe0aa04d6bf1
+Type: Generic
+Name: Audio Switcher
+Author: Narian
+ShortDescription: Switch Windows audio output devices directly from Playnite Desktop and Fullscreen mode.
+InstallerManifestUrl: https://raw.githubusercontent.com/Naerian/playnite-nx-audio-switcher/main/installer.yaml
+SourceUrl: https://github.com/Naerian/playnite-nx-audio-switcher
+Description: Audio Switcher lets you change the default Windows playback device from Playnite, including Fullscreen mode, game context menus, controller quick switch, per-game audio profiles, custom device names and icons, optional device hiding, and theme integration support. Experimental Spatial Sound switching is available through a user-provided SoundVolumeView or svcl executable.
+Tags: ["audio", "fullscreen", "controller", "utility"]
+IconUrl: https://raw.githubusercontent.com/Naerian/playnite-nx-audio-switcher/main/media/icon.png
+Links:
+    GitHub: https://github.com/Naerian/playnite-nx-audio-switcher
+    Support: https://ko-fi.com/naerian


### PR DESCRIPTION
Adds Audio Switcher, a Generic Playnite extension for switching Windows audio output devices from Desktop and Fullscreen mode.

The installer manifest points to the extension repository and the current v0.6.0 release package.