### PR TITLE
Add Metadata AI metadata provider

### DIFF
--- a/addons/metadata/MetaDataIAPlugin_2f42c46c-9e3f-48cb-99b6-7f41f12d9b83.yaml
+++ b/addons/metadata/MetaDataIAPlugin_2f42c46c-9e3f-48cb-99b6-7f41f12d9b83.yaml
@@ -1,0 +1,13 @@
+AddonId: MetaDataIAPlugin_2f42c46c-9e3f-48cb-99b6-7f41f12d9b83
+Type: MetadataProvider
+Name: Metadata AI
+Author: Narian
+ShortDescription: AI-assisted metadata normalization, descriptions and media for Playnite libraries.
+InstallerManifestUrl: https://raw.githubusercontent.com/Naerian/playnite-nx-metadata-ia/main/installer.yaml
+SourceUrl: https://github.com/Naerian/playnite-nx-metadata-ia
+IconUrl: https://raw.githubusercontent.com/Naerian/playnite-nx-metadata-ia/main/media/icon.png
+Tags: [metadata, ai, media, localization, automation]
+Links:
+    GitHub: https://github.com/Naerian/playnite-nx-metadata-ia
+    Support: https://ko-fi.com/naerian
+Description: Metadata AI helps normalize and enrich Playnite libraries with consistent descriptions, tags, categories, features, links, sorting names, covers, icons and backgrounds. It is designed for mixed libraries imported from different stores, emulators, launchers and manual entries, where metadata often ends up using different languages, naming styles and structures. It supports multiple AI providers, local models through LM Studio or Ollama, configurable templates, per-field apply rules and external media sources.


### PR DESCRIPTION
Hi!

This PR adds Metadata AI, a Playnite metadata provider focused on helping users keep large mixed libraries consistent.

The extension is mainly intended for libraries imported from multiple sources such as Steam, GOG, Epic, emulators, random launchers and manual entries, where metadata can easily end up with different description styles, duplicated tags, mixed languages, missing categories, inconsistent features, or no useful sorting names for sequels.

Metadata AI can generate or normalize descriptions, tags, genres, features, developers, publishers, age ratings, regions, categories, links and sorting names using configurable templates and per-field apply rules. It also supports fetching covers, icons and backgrounds from external media sources such as Steam public assets, SteamGridDB, RAWG, MobyGames and IGDB.

It is not meant to be a replacement for validated metadata sources when those already provide exactly what the user needs. The main use case is normalization, translation, restructuring and filling gaps according to the user's own language, templates and rules.

The extension supports several AI providers, including OpenAI, Gemini, Claude, OpenRouter, Groq, LM Studio, Ollama and custom OpenAI-compatible endpoints. For users who do not want paid API usage, local providers such as LM Studio and Ollama are supported.

Repository:
https://github.com/Naerian/playnite-nx-metadata-ia