### PR TITLE
Add FPS Limiter extension

### DIFF
--- a/addons/generic/mjd4219_FPSLimiter.yaml
+++ b/addons/generic/mjd4219_FPSLimiter.yaml
@@ -1,0 +1,23 @@
+AddonId: FPSLimiter_4b308964-9a0d-4775-b7c2-78b92af4d7b6
+Type: Generic
+Name: FPS Limiter
+Author: mjd4219
+ShortDescription: Set per-game FPS caps through RTSS when launching games from Playnite.
+InstallerManifestUrl: https://raw.githubusercontent.com/mjd4219/playnite-fps-limiter/main/manifest/FPSLimiter.yaml
+SourceUrl: https://github.com/mjd4219/playnite-fps-limiter
+Description: |-
+    FPS Limiter lets you configure per-game framerate caps from Playnite's Desktop and Fullscreen menus.
+
+    It uses RivaTuner Statistics Server (RTSS) to apply caps while games are launched through Playnite, then restores the previous RTSS profile state when the game stops.
+
+    Features:
+    * Configurable FPS presets
+    * Custom FPS caps
+    * Fullscreen controller-friendly menu support
+    * Desktop manual target executable override
+    * RTSS auto-detection
+    * One-time RTSS profile access setup for normal, non-admin Playnite
+Tags: ['FPS', 'RTSS', 'Performance', 'Framerate']
+Links:
+    GitHub: https://github.com/mjd4219/playnite-fps-limiter
+    Releases: https://github.com/mjd4219/playnite-fps-limiter/releases


### PR DESCRIPTION
Adds FPS Limiter to the Generic add-on database.

FPS Limiter is a Playnite extension for setting per-game FPS caps through RTSS when launching games from Playnite.

Highlights:
- Desktop and Fullscreen menu support
- Configurable presets and custom caps
- RTSS auto-detection
- One-time RTSS profile access setup for normal, non-admin Playnite
- Restores the previous RTSS profile state when the game stops

Validation:
- Published v1.0.0 release with .pext asset:
  https://github.com/mjd4219/playnite-fps-limiter/releases/tag/v1.0.0
- Added installer manifest:
  https://raw.githubusercontent.com/mjd4219/playnite-fps-limiter/main/manifest/FPSLimiter.yaml
- Verified installer manifest with Playnite Toolbox
- Verified add-on manifest with Playnite Toolbox