### PR TITLE
Add Gamepad Tester addon

### DIFF
--- a/addons/generic/Naerian_GamepadTester.yaml
+++ b/addons/generic/Naerian_GamepadTester.yaml
@@ -7,7 +7,7 @@ InstallerManifestUrl: https://raw.githubusercontent.com/Naerian/playnite-nx-game
 SourceUrl: https://github.com/Naerian/playnite-nx-gamepad-tester
 Description: Gamepad Tester lets you test controllers directly from Playnite Desktop, with live visual layouts, button and trigger feedback, stick diagnostics, calibration helpers, latency checks, input logs, rumble tests, device information, and optional Fullscreen theme integration blocks for theme authors.
 Tags: ["gamepad", "controller", "input", "diagnostics", "fullscreen", "utility"]
-IconUrl: https://raw.githubusercontent.com/Naerian/playnite-nx-gamepad-tester/main/GamepadTester/media/icon.png
+IconUrl: https://raw.githubusercontent.com/Naerian/playnite-nx-gamepad-tester/main/media/icon.png
 Links:
     GitHub: https://github.com/Naerian/playnite-nx-gamepad-tester
     Support: https://ko-fi.com/naerian

--- a/addons/generic/Naerian_GamepadTester.yaml
+++ b/addons/generic/Naerian_GamepadTester.yaml
@@ -1,0 +1,13 @@
+AddonId: GamepadTester_518dc982-32b5-4493-b32d-1f71de2fe4ad
+Type: Generic
+Name: Gamepad Tester
+Author: Narian
+ShortDescription: Test gamepads directly from Playnite with live buttons, sticks, triggers, rumble, latency, and diagnostics.
+InstallerManifestUrl: https://raw.githubusercontent.com/Naerian/playnite-nx-gamepad-tester/main/installer.yaml
+SourceUrl: https://github.com/Naerian/playnite-nx-gamepad-tester
+Description: Gamepad Tester lets you test controllers directly from Playnite Desktop, with live visual layouts, button and trigger feedback, stick diagnostics, calibration helpers, latency checks, input logs, rumble tests, device information, and optional Fullscreen theme integration blocks for theme authors.
+Tags: ["gamepad", "controller", "input", "diagnostics", "fullscreen", "utility"]
+IconUrl: https://raw.githubusercontent.com/Naerian/playnite-nx-gamepad-tester/main/GamepadTester/media/icon.png
+Links:
+    GitHub: https://github.com/Naerian/playnite-nx-gamepad-tester
+    Support: https://ko-fi.com/naerian


### PR DESCRIPTION
Playnite NX Gamepad Tester is a Playnite extension for testing controllers directly from Playnite Desktop mode.

It is designed for couch, TV, handheld-PC, and console-like setups where users want to verify gamepad buttons, sticks, triggers, rumble, drift, latency, and device metadata without leaving Playnite.