### PR TITLE
Add Steam Account Switcher addon

### DIFF
--- a/addons/generic/SteamAccountSwitcher_AxharKhan.yaml
+++ b/addons/generic/SteamAccountSwitcher_AxharKhan.yaml
@@ -1,0 +1,9 @@
+AddonId: SteamAccountSwitcher_AxharKhan
+Type: Generic
+Name: Steam Account Switcher
+Author: AxharKhan
+ShortDescription: Quickly and Automatically switch between multiple Steam accounts from Playnite when launching games.
+InstallerManifestUrl: https://raw.githubusercontent.com/AxharKhan/PlayniteSteamAccountSwitcher/main/installer.yaml
+SourceUrl: https://github.com/AxharKhan/PlayniteSteamAccountSwitcher
+Links:
+    GitHub: https://github.com/AxharKhan/PlayniteSteamAccountSwitcher


### PR DESCRIPTION
Adds Steam Account Switcher addon.

This addon can save and use multiple steam accounts (using the additional steam accounts library integration), and switches account when launching a game from a different steam account. Making multiple steam account integrations better in playnite.