### PR TITLE
Add GameHQ Integration

### DIFF
--- a/addons/generic/underfusion_GameHQ_Integration.yaml
+++ b/addons/generic/underfusion_GameHQ_Integration.yaml
@@ -1,0 +1,22 @@
+AddonId: GameHQ_Integration
+Type: Generic
+Name: GameHQ Integration
+Author: underfusion
+ShortDescription: Connect Playnite to GameHQ for controller-first screenshots and recent gameplay capture.
+InstallerManifestUrl: https://raw.githubusercontent.com/underfusion/GameHQ/main/integrations/playnite/InstallerManifest.yaml
+SourceUrl: https://github.com/underfusion/GameHQ
+Description: |-
+    Connects Playnite with GameHQ, a controller-first screenshot and recent gameplay capture application for Windows.
+    - Discovers and launches GameHQ when needed.
+    - Forwards game start and stop lifecycle events.
+    - Restores active game state after reconnects.
+    - Provides connection, version and path diagnostics.
+Tags: ["Generic", "Capture", "Screenshots", "Replay", "Integration"]
+Links:
+    GitHub: https://github.com/underfusion/GameHQ
+    GameHQ Downloads: https://github.com/underfusion/GameHQ/releases/latest
+    Manual Plugin Download: https://github.com/underfusion/GameHQ/releases/download/playnite-v0.4.12/GameHQ_Playnite_Integration_0_4_12.pext
+IconUrl: https://raw.githubusercontent.com/underfusion/GameHQ/main/integrations/playnite/icon.png
+Screenshots:
+    - Thumbnail: https://raw.githubusercontent.com/underfusion/GameHQ/main/docs/assets/gamehq-gallery.png
+      Image: https://raw.githubusercontent.com/underfusion/GameHQ/main/docs/assets/gamehq-gallery.png


### PR DESCRIPTION
## Add-on

GameHQ Integration is a generic Playnite plugin connecting Playnite with the
GameHQ Windows screenshot and recent-gameplay capture application.

## Features

- discovers and launches GameHQ when needed;
- forwards game start and stop lifecycle events;
- restores active game state after reconnects;
- provides connection, version and path diagnostics.

## Presentation

- uses the existing GameHQ integration logo;
- uses the existing GameHQ gallery screenshot;
- includes repository, download and manual plugin links.

## Validation

- the exact database manifest passed Playnite 10.56 Toolbox `verify addon`;
- the linked installer manifest passed Toolbox verification;
- the immutable public `0.4.12` `.pext` package downloaded successfully;
- the public icon and screenshot URLs returned HTTP 200.
