### PR TITLE
Add epic collections importer

### DIFF
--- a/addons/generic/Luxtos_EpicCollectionsImporter.yaml
+++ b/addons/generic/Luxtos_EpicCollectionsImporter.yaml
@@ -6,11 +6,7 @@ ShortDescription: Simple utility to import Epic collections to Playnite
 InstallerManifestUrl: https://github.com/rfastolfe/playnite-epic-collection-importer-plugin/blob/main/Manifests/Luxtos_EpicCollectionsImporter.yaml
 SourceUrl: https://github.com/rfastolfe/playnite-epic-collection-importer-plugin
 Description: Gives you an option to import basic Epic collections to Playnite.
-Version: 1.0
-Module: EpicCollectionsImporter.dll
-Type: GenericPlugin
-Icon: icon.png
 Links:
-  - GitHub: https://github.com/rfastolfe/playnite-epic-collection-importer-plugin
-  - Issue Tracker: https://github.com/rfastolfe/playnite-epic-collection-importer-plugin/issues
+    GitHub: https://github.com/rfastolfe/playnite-epic-collection-importer-plugin
+    Issue Tracker: https://github.com/rfastolfe/playnite-epic-collection-importer-plugin/issues
 IconUrl: https://github.com/rfastolfe/playnite-epic-collection-importer-plugin/blob/main/icon.png

--- a/addons/generic/Luxtos_EpicCollectionsImporter.yaml
+++ b/addons/generic/Luxtos_EpicCollectionsImporter.yaml
@@ -1,0 +1,16 @@
+﻿Id: Luxtos_EpicCollectionsImporter
+Type: Generic
+Name: Epic Collections Importer
+Author: Luxtos
+ShortDescription: Simple utility to import Epic collections to Playnite
+InstallerManifestUrl: https://github.com/rfastolfe/playnite-epic-collection-importer-plugin/blob/main/Manifests/Luxtos_EpicCollectionsImporter.yaml
+SourceUrl: https://github.com/rfastolfe/playnite-epic-collection-importer-plugin
+Description: Gives you an option to import basic Epic collections to Playnite.
+Version: 1.0
+Module: EpicCollectionsImporter.dll
+Type: GenericPlugin
+Icon: icon.png
+Links:
+  - GitHub: https://github.com/rfastolfe/playnite-epic-collection-importer-plugin
+  - Issue Tracker: https://github.com/rfastolfe/playnite-epic-collection-importer-plugin/issues
+IconUrl: https://github.com/rfastolfe/playnite-epic-collection-importer-plugin/blob/main/icon.png


### PR DESCRIPTION
# Playnite Epic Collection Importer Plugin

Simple utility to allow you to import your Epic collections into Playnite as categories.

You can import the collections by using a main menu option. It obviously requires you to have [Epic library plugin](https://playnite.link/addons.html#EpicGamesLibrary_Builtin) installed, you also need to be logged in to Epic.

## Credits

- [Playnite](https://playnite.link/) by [JosefNemec](https://github.com/JosefNemec)
- [Steam Collection Importer Plugin](https://github.com/Yalgrin/playnite-steam-collection-importer-plugin) by [Yalgrin](https://github.com/Yalgrin/)