### PR TITLE
Add HDR & Upscale Manager

### DIFF
--- a/addons/generic/matheusfaustino_HdrUpscaleManager.yaml
+++ b/addons/generic/matheusfaustino_HdrUpscaleManager.yaml
@@ -1,0 +1,19 @@
+AddonId: hdr-upscale-manager
+Type: Generic
+Name: HDR & Upscale Manager
+Author: matheusfaustino
+ShortDescription: 'Per-game HDR and upscaler (FSR/OptiScaler) setup for Playnite.'
+Description: >
+  Configure ReShade, RenoDX/Luma HDR mods, DXVK, and OptiScaler (FSR/XeSS) per game from inside Playnite. AMD-focused today, with NVIDIA support planned.
+Tags: ['HDR', 'Upscaling', 'ReShade', 'Mods', 'Luma', 'RenoDX']
+SourceUrl: https://github.com/matheusfaustino/playnite-hdr-upscale-manager
+IconUrl: https://raw.githubusercontent.com/matheusfaustino/playnite-hdr-upscale-manager/master/Resources/icon.png
+InstallerManifestUrl: https://raw.githubusercontent.com/matheusfaustino/playnite-hdr-upscale-manager/master/addon_manifest.json
+Links:
+  Issues Tracker: https://github.com/matheusfaustino/playnite-hdr-upscale-manager/issues
+  Documentation: https://github.com/matheusfaustino/playnite-hdr-upscale-manager/blob/master/README.md
+Screenshots:
+  - Thumbnail: https://raw.githubusercontent.com/matheusfaustino/playnite-hdr-upscale-manager/master/Screenshots/desktop-manager.png
+    Image: https://raw.githubusercontent.com/matheusfaustino/playnite-hdr-upscale-manager/master/Screenshots/desktop-manager.png
+  - Thumbnail: https://raw.githubusercontent.com/matheusfaustino/playnite-hdr-upscale-manager/master/Screenshots/fullscreen-manager.png
+    Image: https://raw.githubusercontent.com/matheusfaustino/playnite-hdr-upscale-manager/master/Screenshots/fullscreen-manager.png


### PR DESCRIPTION
Hi o/ 

I would like to add another addon of mine. This one is m attempt to automate some cool projects and o make them more accessible via gamepad. The focus is gamepad, but supports desktop as well. Hope it adds value to the commuity. 

> Lets you configure ReShade, RenoDX/Luma HDR mods, DXVK+Lilium HDR, and OptiScaler (FSR/XeSS substitution for DLSS-only titles) directly from a per-game manager window, in both Desktop and Fullscreen. Also includes an opt-in OS-level HDR toggle around play sessions.

Haev a nice day. Best o/ 