### PR TITLE
Add Controller Session Manager addon

### DIFF
--- a/addons/generic/Naerian_ControllerSessionManager.yaml
+++ b/addons/generic/Naerian_ControllerSessionManager.yaml
@@ -1,0 +1,14 @@
+AddonId: ControllerSessionManager_6f3e7a21-98f4-4f2b-92ad-3fc0e6e941dc
+Type: Generic
+Name: Controller Session Manager
+Author: Narian
+ShortDescription: Detect controllers and protect active game sessions when a participating controller disconnects.
+InstallerManifestUrl: https://raw.githubusercontent.com/Naerian/playnite-nx-session-controller-manager/main/installer.yaml
+SourceUrl: https://github.com/Naerian/playnite-nx-session-controller-manager
+Description: |
+  Controller Session Manager identifies connected controllers, tracks which ones actually participate in a game session and reacts when a participant disconnects. It supports adaptive controller handover and local multiplayer, configurable Fullscreen notifications and an external disconnect overlay, conservative pause policies, custom names and icons, trustworthy battery states, Desktop quick access, theme integration and privacy-conscious support reports.
+IconUrl: https://raw.githubusercontent.com/Naerian/playnite-nx-session-controller-manager/main/media/icon.png
+Tags: ['controller', 'gamepad', 'battery', 'fullscreen', 'accessibility', 'utility']
+Links:
+  GitHub: https://github.com/Naerian/playnite-nx-session-controller-manager
+  Support: https://ko-fi.com/naerian

--- a/addons/generic/Naerian_ControllerSessionManager.yaml
+++ b/addons/generic/Naerian_ControllerSessionManager.yaml
@@ -11,4 +11,5 @@ IconUrl: https://raw.githubusercontent.com/Naerian/playnite-nx-session-controlle
 Tags: ['controller', 'gamepad', 'battery', 'fullscreen', 'accessibility', 'utility']
 Links:
   GitHub: https://github.com/Naerian/playnite-nx-session-controller-manager
+  Wiki: https://github.com/Naerian/playnite-nx-session-controller-manager/wiki
   Support: https://ko-fi.com/naerian


### PR DESCRIPTION
Controller Session Manager is a generic Playnite extension that identifies connected controllers and protects active game sessions when a participating controller disconnects.

The extension supports adaptive controller transfer for single-player and local multiplayer, configurable full-screen notifications and disconnection overlays, conservative pause policies, controller customization, verified battery providers, theme integration, and privacy-respecting support reports.

The idea is to have a system where, if a controller disconnects during a game, the game pauses or suspends and an overlay appears on screen informing the user that the controller has disconnected. If the Playnite interface is in full-screen view, a notification will appear indicating the same, but without blocking the screen.

It also allows monitoring the battery levels of connected controllers, for those that can be read.

More information on the Wiki: https://github.com/Naerian/playnite-nx-session-controller-manager/wiki

The plugin and installer manifests have passed Playnite Toolbox verification. The package, installer manifest, and icon URLs are publicly accessible.