### PR TITLE
Add Cloud Storage library plugin

### DIFF
--- a/addons/library/CloudSource_a6fd3d1b-450e-4c8b-8476-ce14ad3ab3c2.yaml
+++ b/addons/library/CloudSource_a6fd3d1b-450e-4c8b-8476-ce14ad3ab3c2.yaml
@@ -1,0 +1,21 @@
+AddonId: CloudSource_a6fd3d1b-450e-4c8b-8476-ce14ad3ab3c2
+Type: GameLibrary
+Name: Cloud Storage
+Author: GreenFuze
+ShortDescription: Discover and install games stored in Google Drive and OneDrive.
+InstallerManifestUrl: https://raw.githubusercontent.com/GreenFuze/PlayniteCloudSource/main/installer.yaml
+SourceUrl: https://github.com/GreenFuze/PlayniteCloudSource
+Description: >-
+  Connect a read-only Google Drive or OneDrive folder as a Playnite library.
+  Cloud Storage discovers archives, installer bundles, and ROMs; installs them
+  below one managed directory; and provides managed uninstall and source
+  reconciliation.
+Tags:
+  - cloud
+  - storage
+  - google-drive
+  - onedrive
+Links:
+  Website: https://github.com/GreenFuze/PlayniteCloudSource
+  Privacy policy: https://github.com/GreenFuze/PlayniteCloudSource/blob/main/PRIVACY.md
+IconUrl: https://raw.githubusercontent.com/GreenFuze/PlayniteCloudSource/main/src/CloudSource.Playnite/Resources/cloud-storage.png

--- a/addons/library/CloudSource_a6fd3d1b-450e-4c8b-8476-ce14ad3ab3c2.yaml
+++ b/addons/library/CloudSource_a6fd3d1b-450e-4c8b-8476-ce14ad3ab3c2.yaml
@@ -16,7 +16,7 @@ Tags:
   - google-drive
   - onedrive
 Links:
-  Website: https://greenfuze.github.io/PlayniteCloudSource/
-  Privacy policy: https://greenfuze.github.io/PlayniteCloudSource/privacy.html
-  Terms of service: https://greenfuze.github.io/PlayniteCloudSource/terms.html
+  Website: https://greenfuze.is-a.dev/PlayniteCloudSource/
+  Privacy policy: https://greenfuze.is-a.dev/PlayniteCloudSource/privacy.html
+  Terms of service: https://greenfuze.is-a.dev/PlayniteCloudSource/terms.html
 IconUrl: https://raw.githubusercontent.com/GreenFuze/PlayniteCloudSource/main/src/CloudSource.Playnite/Resources/cloud-storage.png

--- a/addons/library/CloudSource_a6fd3d1b-450e-4c8b-8476-ce14ad3ab3c2.yaml
+++ b/addons/library/CloudSource_a6fd3d1b-450e-4c8b-8476-ce14ad3ab3c2.yaml
@@ -16,6 +16,7 @@ Tags:
   - google-drive
   - onedrive
 Links:
-  Website: https://github.com/GreenFuze/PlayniteCloudSource
-  Privacy policy: https://github.com/GreenFuze/PlayniteCloudSource/blob/main/PRIVACY.md
+  Website: https://greenfuze.github.io/PlayniteCloudSource/
+  Privacy policy: https://greenfuze.github.io/PlayniteCloudSource/privacy.html
+  Terms of service: https://greenfuze.github.io/PlayniteCloudSource/terms.html
 IconUrl: https://raw.githubusercontent.com/GreenFuze/PlayniteCloudSource/main/src/CloudSource.Playnite/Resources/cloud-storage.png


### PR DESCRIPTION
## Summary

Adds Cloud Storage, a Playnite library plugin for discovering and installing games stored in Google Drive and Microsoft OneDrive.

The plugin uses read-only provider permissions and supports ZIP, 7z, RAR, installer bundles, and common ROM formats below one managed local storage root.

## Validation

- Playnite Toolbox installer manifest verification passed.
- Playnite Toolbox add-on manifest verification passed.
- Public v0.4.1 `.pext` release is available and its SHA-256 digest matches the locally verified package.
- Source, website, privacy policy, terms of service, icon, and installer manifest URLs are publicly reachable.