### PR TITLE
Add Game Routines

### DIFF
--- a/addons/generic/felipeaucc_GameRoutines.yaml
+++ b/addons/generic/felipeaucc_GameRoutines.yaml
@@ -8,11 +8,11 @@ SourceUrl: https://github.com/felipeaucc/playnite-gameroutines-plugin
 IconUrl: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/source/icon.png
 Description: >-
   Game Routines helps you manage recurring and long-term activities for your games. Create multiple
-  routines per game, add checklists, set Never, Daily, Weekly, or Biweekly reset schedules, schedule
+  routines per game, add checklists, set Never, Daily, Weekly, or Biweekly reset schedules, add
   reminders, and track completion. Open checklists from the game context menu or in separate windows,
   and optionally manage a Tasks Available! tag for unfinished routines. Game Routines works with
   Playnite's standard Default Desktop theme. No third-party theme is required. Some themes can
-  optionally show extra Game Routines controls directly in the game view.
+  show optional Game Routines controls directly in the game view.
 Links:
   GitHub: https://github.com/felipeaucc/playnite-gameroutines-plugin
   Issues: https://github.com/felipeaucc/playnite-gameroutines-plugin/issues

--- a/addons/generic/felipeaucc_GameRoutines.yaml
+++ b/addons/generic/felipeaucc_GameRoutines.yaml
@@ -1,0 +1,31 @@
+AddonId: GameRoutines_cb076ecb-ea40-4036-8094-f1c554566b49
+Type: Generic
+Name: Game Routines
+Author: felipeaucc
+ShortDescription: Manage recurring and long-term game activities with routines, checklists, schedules, and reminders.
+InstallerManifestUrl: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/installer.yaml
+SourceUrl: https://github.com/felipeaucc/playnite-gameroutines-plugin
+IconUrl: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/source/icon.png
+Description: >-
+  Game Routines manages recurring and long-term game activities with multiple named routines,
+  per-routine checklists, reset schedules, reminders, and task completion tracking. It also provides
+  modeless checklist windows, context-menu actions, persistent Playnite notifications, optional task
+  tagging, and enhanced theme UI elements. Version 0.9.0 is designed and tested for FusionX 2.1.1
+  using the version-specific integration provided by the Game Routines repository. Other Playnite
+  Desktop themes are not currently supported and may display Game Routines controls incorrectly.
+  The integration is not included in the official FusionX project, and Game Routines is not
+  affiliated with FusionX or Playnite.
+Links:
+  GitHub: https://github.com/felipeaucc/playnite-gameroutines-plugin
+  Issues: https://github.com/felipeaucc/playnite-gameroutines-plugin/issues
+Screenshots:
+  - Thumbnail: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/01-settings.png
+    Image: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/01-settings.png
+  - Thumbnail: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/03-fusionx-checklists.png
+    Image: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/03-fusionx-checklists.png
+  - Thumbnail: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/02-manage-checklist.png
+    Image: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/02-manage-checklist.png
+  - Thumbnail: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/04-fusionx-tasks-indicator.png
+    Image: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/04-fusionx-tasks-indicator.png
+  - Thumbnail: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/05-context-menu.png
+    Image: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/05-context-menu.png

--- a/addons/generic/felipeaucc_GameRoutines.yaml
+++ b/addons/generic/felipeaucc_GameRoutines.yaml
@@ -7,26 +7,19 @@ InstallerManifestUrl: https://raw.githubusercontent.com/felipeaucc/playnite-game
 SourceUrl: https://github.com/felipeaucc/playnite-gameroutines-plugin
 IconUrl: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/source/icon.png
 Description: >-
-  Game Routines manages recurring and long-term game activities with multiple named routines,
-  per-routine checklists, reset schedules, reminders, and task completion tracking. It also provides
-  pop-out checklist windows, context-menu actions, persistent Playnite notifications, and optional
-  task tagging. Core functionality works independently of the active Playnite Desktop theme.
-  Playnite's stock Default Desktop theme is officially validated for the core experience, while
-  FusionX 2.1.1 is regression-tested as the primary optional enhanced integration and reference
-  implementation. FusionX is not required to use the extension. Some screenshots show additional
-  embedded Game Routines controls in the modified FusionX setup used during development; those
-  additions are not currently included in the official FusionX theme.
+  Game Routines helps you manage recurring and long-term activities for your games. Create multiple
+  routines per game, add checklists, set Never, Daily, Weekly, or Biweekly reset schedules, schedule
+  reminders, and track completion. Open checklists from the game context menu or in separate windows,
+  and optionally manage a Tasks Available! tag for unfinished routines. Game Routines works with
+  Playnite's standard Default Desktop theme. No third-party theme is required. Some themes can
+  optionally show extra Game Routines controls directly in the game view.
 Links:
   GitHub: https://github.com/felipeaucc/playnite-gameroutines-plugin
   Issues: https://github.com/felipeaucc/playnite-gameroutines-plugin/issues
 Screenshots:
   - Thumbnail: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/01-settings.png
     Image: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/01-settings.png
-  - Thumbnail: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/03-fusionx-checklists.png
-    Image: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/03-fusionx-checklists.png
   - Thumbnail: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/02-manage-checklist.png
     Image: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/02-manage-checklist.png
-  - Thumbnail: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/04-fusionx-tasks-indicator.png
-    Image: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/04-fusionx-tasks-indicator.png
   - Thumbnail: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/05-context-menu.png
     Image: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plugin/main/assets/screenshots/05-context-menu.png

--- a/addons/generic/felipeaucc_GameRoutines.yaml
+++ b/addons/generic/felipeaucc_GameRoutines.yaml
@@ -9,12 +9,13 @@ IconUrl: https://raw.githubusercontent.com/felipeaucc/playnite-gameroutines-plug
 Description: >-
   Game Routines manages recurring and long-term game activities with multiple named routines,
   per-routine checklists, reset schedules, reminders, and task completion tracking. It also provides
-  modeless checklist windows, context-menu actions, persistent Playnite notifications, optional task
-  tagging, and enhanced theme UI elements. Version 0.9.0 is designed and tested for FusionX 2.1.1
-  using the version-specific integration provided by the Game Routines repository. Other Playnite
-  Desktop themes are not currently supported and may display Game Routines controls incorrectly.
-  The integration is not included in the official FusionX project, and Game Routines is not
-  affiliated with FusionX or Playnite.
+  pop-out checklist windows, context-menu actions, persistent Playnite notifications, and optional
+  task tagging. Core functionality works independently of the active Playnite theme, and FusionX
+  is not required to use the extension. Version 0.9.0 was developed and tested primarily with
+  FusionX, while other Playnite Desktop themes have not yet been officially validated and may have
+  missing or incorrectly rendered Game Routines UI elements. Some screenshots show additional
+  embedded Game Routines controls in the modified FusionX setup used during development; those
+  additions are not currently included in the official FusionX theme.
 Links:
   GitHub: https://github.com/felipeaucc/playnite-gameroutines-plugin
   Issues: https://github.com/felipeaucc/playnite-gameroutines-plugin/issues

--- a/addons/generic/felipeaucc_GameRoutines.yaml
+++ b/addons/generic/felipeaucc_GameRoutines.yaml
@@ -10,10 +10,10 @@ Description: >-
   Game Routines manages recurring and long-term game activities with multiple named routines,
   per-routine checklists, reset schedules, reminders, and task completion tracking. It also provides
   pop-out checklist windows, context-menu actions, persistent Playnite notifications, and optional
-  task tagging. Core functionality works independently of the active Playnite theme, and FusionX
-  is not required to use the extension. Version 0.9.0 was developed and tested primarily with
-  FusionX, while other Playnite Desktop themes have not yet been officially validated and may have
-  missing or incorrectly rendered Game Routines UI elements. Some screenshots show additional
+  task tagging. Core functionality works independently of the active Playnite Desktop theme.
+  Playnite's stock Default Desktop theme is officially validated for the core experience, while
+  FusionX 2.1.1 is regression-tested as the primary optional enhanced integration and reference
+  implementation. FusionX is not required to use the extension. Some screenshots show additional
   embedded Game Routines controls in the modified FusionX setup used during development; those
   additions are not currently included in the official FusionX theme.
 Links:


### PR DESCRIPTION
## Add-on

Adds Game Routines to the Playnite Add-on Database.

- Type: Generic
- Version: 1.0.0
- Author: felipeaucc
- Source: https://github.com/felipeaucc/playnite-gameroutines-plugin
- Release: https://github.com/felipeaucc/playnite-gameroutines-plugin/releases/tag/v1.0.0

The add-on and installer manifests both pass Playnite Toolbox verification.

Game Routines 1.0.0 is the first stable release. It works with Playnite's standard Default Desktop theme, and no third-party theme is required. Some themes can show optional Game Routines controls directly in the game view.