### PR TITLE
Add Web Emulator

### DIFF
--- a/addons/generic/GreenFuze_WebEmulator.yaml
+++ b/addons/generic/GreenFuze_WebEmulator.yaml
@@ -1,0 +1,20 @@
+AddonId: WebEmulator_41d5bc40-a7e8-46a6-888e-d52cf719c397
+Type: Generic
+Name: Web Emulator
+Author: GreenFuze
+ShortDescription: Runs supported classic games in your browser through managed web-emulator profiles.
+InstallerManifestUrl: https://raw.githubusercontent.com/GreenFuze/PlayniteWebEmulator/master/installer.yaml
+SourceUrl: https://github.com/GreenFuze/PlayniteWebEmulator
+Description: |-
+  Registers managed Playnite emulator profiles backed by EmulatorJS, js-dos,
+  and ScummVM WebAssembly. Runtimes are downloaded from pinned upstream sources
+  on first use, hash-verified, and stored in Playnite's extension-data folder.
+  The add-on does not include or download games, ROMs, firmware, or BIOS files.
+Tags: ["Emulation", "Browser", "DOS", "ScummVM", "Arcade"]
+Links:
+  GitHub: https://github.com/GreenFuze/PlayniteWebEmulator
+  Support: https://github.com/GreenFuze/PlayniteWebEmulator/issues
+  Credits: https://github.com/GreenFuze/PlayniteWebEmulator/blob/master/THIRD_PARTY_NOTICES.md
+UserAgreement:
+  Updated: 2026-08-27
+  AgreementUrl: https://raw.githubusercontent.com/GreenFuze/PlayniteWebEmulator/master/USER_AGREEMENT.md


### PR DESCRIPTION
## Summary

Adds Web Emulator, a generic Playnite add-on that registers managed browser-emulator profiles backed by EmulatorJS, js-dos, and ScummVM WebAssembly.

## Release verification

- Public source repository and Apache-2.0 project license
- Public v0.1.0 release with a Playnite .pext package
- Installer and add-on manifests pass Playnite Toolbox verification
- Third-party emulator credits, source links, and license restrictions are included in the package and exposed in Playnite
- Catalog user agreement discloses first-use runtime downloads and the non-commercial Snes9x, PicoDrive, and MAME 2003-Plus terms
- The add-on package contains no emulator runtime binaries, games, ROMs, firmware, or BIOS files
- Release build succeeds with zero warnings and all 13 tests pass