### PR TITLE
Add Syncnite

### DIFF
--- a/addons/generic/Syncnite.yaml
+++ b/addons/generic/Syncnite.yaml
@@ -1,0 +1,11 @@
+AddonId: Syncnite
+Type: Generic
+Name: Syncnite
+Author: Tolga Yigit
+ShortDescription: Sync your Playnite library to the cloud and browse or edit it from any browser.
+InstallerManifestUrl: https://raw.githubusercontent.com/TolgaYigit/syncnite-playnite-plugin/main/InstallerManifest.yaml
+SourceUrl: https://github.com/TolgaYigit/syncnite-playnite-plugin
+IconUrl: https://raw.githubusercontent.com/TolgaYigit/syncnite-playnite-plugin/main/pluginicon.png
+Description: 'Syncnite pushes your Playnite library to the cloud and pulls edits back down. Pair once with a short code from the web app, and Syncnite keeps your library in sync automatically: playtime, install status, and covers flow up to the web, while tags, notes, and completion status you set on the web land back in Playnite. Works alongside PlayniteAchievements (syncs achievement counts) and Duplicate Hider (hidden copies still sync, powering an Also owned on switcher on the web).'
+Tags: [cloud, sync, backup]
+Links: {GitHub: https://github.com/TolgaYigit/syncnite-playnite-plugin, Website: https://syncnite.com, Feedback: https://github.com/TolgaYigit/syncnite-feedback}

--- a/addons/generic/Syncnite.yaml
+++ b/addons/generic/Syncnite.yaml
@@ -8,4 +8,7 @@ SourceUrl: https://github.com/TolgaYigit/syncnite-playnite-plugin
 IconUrl: https://raw.githubusercontent.com/TolgaYigit/syncnite-playnite-plugin/main/pluginicon.png
 Description: 'Syncnite pushes your Playnite library to the cloud and pulls edits back down. Pair once with a short code from the web app, and Syncnite keeps your library in sync automatically: playtime, install status, and covers flow up to the web, while tags, notes, and completion status you set on the web land back in Playnite. Works alongside PlayniteAchievements (syncs achievement counts) and Duplicate Hider (hidden copies still sync, powering an Also owned on switcher on the web).'
 Tags: [cloud, sync, backup]
-Links: {GitHub: https://github.com/TolgaYigit/syncnite-playnite-plugin, Website: https://syncnite.com, Feedback: https://github.com/TolgaYigit/syncnite-feedback}
+Links:
+    GitHub: https://github.com/TolgaYigit/syncnite-playnite-plugin
+    Website: https://syncnite.com
+    Feedback: https://github.com/TolgaYigit/syncnite-feedback


### PR DESCRIPTION
Syncnite is a Playnite plugin that syncs your library to a cloud service, where it can be browsed and edited from a web app. It's a two-way sync: playtime, install status, and covers push up to the web; tags, notes, and completion status set on the web land back in Playnite automatically.

- Source: https://github.com/TolgaYigit/syncnite-playnite-plugin
- Website: https://syncnite.com
- License: MIT

Both the addon manifest and the installer manifest pass `Toolbox.exe verify`.