### PR TITLE
Add Offloader Plugin

### DIFF
--- a/addons/generic/rosystain_Offloader.yaml
+++ b/addons/generic/rosystain_Offloader.yaml
@@ -1,0 +1,7 @@
+AddonId: Offloader_5180751b-c8af-41cf-b9de-76253984e71c
+Type: Generic
+InstallerManifestUrl: https://raw.githubusercontent.com/rosystain/playnite-offloader/refs/heads/main/manifest.yaml
+ShortDescription: Offloader is a cold-storage archiving extension designed for Playnite. When SSD storage is constrained, Offloader allows you to safely migrate space-consuming games to secondary HDD or NAS storage while preserving full library metadata. Games can be restored at any time via Playnite's native installation workflow.
+Name: Offloader
+Author: Chock
+SourceUrl: https://github.com/rosystain/playnite-offloader#documentation

--- a/addons/generic/rosystain_Offloader.yaml
+++ b/addons/generic/rosystain_Offloader.yaml
@@ -4,4 +4,4 @@ InstallerManifestUrl: https://raw.githubusercontent.com/rosystain/playnite-offlo
 ShortDescription: Offloader is a cold-storage archiving extension designed for Playnite. When SSD storage is constrained, Offloader allows you to safely migrate space-consuming games to secondary HDD or NAS storage while preserving full library metadata. Games can be restored at any time via Playnite's native installation workflow.
 Name: Offloader
 Author: Chock
-SourceUrl: https://github.com/rosystain/playnite-offloader#documentation
+SourceUrl: https://github.com/rosystain/playnite-offloader


### PR DESCRIPTION
Offloader is a cold-storage archiving extension designed for [Playnite](https://playnite.link/). When SSD storage is constrained, Offloader allows you to safely migrate space-consuming games to secondary HDD or NAS storage while preserving full library metadata. Games can be restored at any time via Playnite's native installation workflow.

**Key Features**
- On-Demand Cold Storage: Archives games into isolated directories by GameId to avoid naming conflicts. Once verified, local files are safely purged, and the game status smoothly transitions to "Uninstalled."
- Native Restore Flow: Registered archives act directly as Playnite install providers, allowing one-click restoration back to local storage.
- Controlled Non-Destructive Sync: All push operations require explicit user interaction with zero silent background overwrites. Concurrency locks per game prevent cross-process collisions.
- Efficient Incremental Transfer: Powered by the native multithreaded robocopy engine with millisecond-level skip checks and safe resume capabilities.

Repo: https://github.com/rosystain/playnite-offloader