### PR TITLE
Add JoePittsy_DiskDashboard (generic plugin)

### DIFF
--- a/addons/generic/JoePittsy_DiskDashboard.yaml
+++ b/addons/generic/JoePittsy_DiskDashboard.yaml
@@ -1,0 +1,8 @@
+AddonId: JoePittsy_DiskDashboard
+Packages:
+  - Version: 1.1.0
+    RequiredApiVersion: 6.16.0
+    ReleaseDate: 2026-09-07
+    PackageUrl: https://github.com/JoePittsy/playnite-disk-dashboard/releases/download/v1.1.0/DiskDashboard.pext
+    Changelog:
+      - Initial add-on database release.


### PR DESCRIPTION
Adds **Disk Dashboard**, a generic desktop plugin that adds a **Storage** view to the sidebar: per-drive, per-game, and per-store install-size donut charts, a full per-drive install list, and game actions (Play / Show in library / Open install folder / Uninstall). Read-only otherwise.

- AddonId: `JoePittsy_DiskDashboard` (new, unique)
- Source: https://github.com/JoePittsy/playnite-disk-dashboard
- Release: https://github.com/JoePittsy/playnite-disk-dashboard/releases/tag/v1.1.0
- Built against SDK 6.16 (`RequiredApiVersion: 6.16.0`)

The `.pext` is hosted as a GitHub release asset and the manifest's `PackageUrl` points directly at it.
