### PR TITLE
Add minecraft modpack importers

### DIFF
--- a/addons/CurseForgeImporter_Playnite.yaml
+++ b/addons/CurseForgeImporter_Playnite.yaml
@@ -1,0 +1,11 @@
+﻿AddonId: CurseForgeImporter_Playnite
+Packages:
+  - Version: 1.0.0
+    RequiredApiVersion: 6.2.2
+    ReleaseDate: 2026-09-11
+    PackageUrl: https://github.com/gokublacko7/playnite-minecraft-modpacks/releases/download/v1.0.0/CurseForgeImporter.pext
+    Changelog:
+      - Standalone game tiles for CurseForge Minecraft modpacks
+      - High-res cover art and thumbnail synchronization
+      - Smart 1-click auto-launch with dynamic DPI & resolution awareness
+      - Auto-sync on Playnite startup and library refresh

--- a/addons/CurseForgeImporter_Playnite.yaml
+++ b/addons/CurseForgeImporter_Playnite.yaml
@@ -1,9 +1,9 @@
-﻿AddonId: CurseForgeImporter_Playnite
+AddonId: CurseForgeImporter_Playnite
 Packages:
-  - Version: 1.0.0
+  - Version: 1.0.1
     RequiredApiVersion: 6.2.2
     ReleaseDate: 2026-09-11
-    PackageUrl: https://github.com/gokublacko7/playnite-minecraft-modpacks/releases/download/v1.0.0/CurseForgeImporter.pext
+    PackageUrl: https://github.com/gokublacko7/playnite-minecraft-modpacks/releases/download/v1.0.1/CurseForgeImporter.pext
     Changelog:
       - Standalone game tiles for CurseForge Minecraft modpacks
       - High-res cover art and thumbnail synchronization

--- a/addons/FTBImporter_Playnite.yaml
+++ b/addons/FTBImporter_Playnite.yaml
@@ -1,0 +1,12 @@
+﻿AddonId: FTBImporter_Playnite
+Packages:
+  - Version: 1.0.0
+    RequiredApiVersion: 6.2.2
+    ReleaseDate: 2026-09-11
+    PackageUrl: https://github.com/gokublacko7/playnite-minecraft-modpacks/releases/download/v1.0.0/FTBImporter.pext
+    Changelog:
+      - Standalone game tiles for Feed The Beast (FTB) modpacks
+      - Auto-discovery from FTB settings.json and custom instances
+      - High-res logo and artwork sync
+      - Direct hover-to-play automated 1-click launch
+      - Auto-sync on Playnite startup and library refresh

--- a/addons/FTBImporter_Playnite.yaml
+++ b/addons/FTBImporter_Playnite.yaml
@@ -1,9 +1,9 @@
-﻿AddonId: FTBImporter_Playnite
+AddonId: FTBImporter_Playnite
 Packages:
-  - Version: 1.0.0
+  - Version: 1.0.1
     RequiredApiVersion: 6.2.2
     ReleaseDate: 2026-09-11
-    PackageUrl: https://github.com/gokublacko7/playnite-minecraft-modpacks/releases/download/v1.0.0/FTBImporter.pext
+    PackageUrl: https://github.com/gokublacko7/playnite-minecraft-modpacks/releases/download/v1.0.1/FTBImporter.pext
     Changelog:
       - Standalone game tiles for Feed The Beast (FTB) modpacks
       - Auto-discovery from FTB settings.json and custom instances


### PR DESCRIPTION
### Summary of Changes

Adds installer manifests for two new generic extensions to import and launch Minecraft modpacks as standalone game tiles:

1. **CurseForge Modpack Importer (`CurseForgeImporter_Playnite`)**:
   - Automatically imports installed CurseForge Minecraft modpacks with cover art, background banners, and icons.
   - Provides automated 1-click launching with clean restart handling.
   - Includes full multi-monitor and display DPI scaling awareness.

2. **FTB Modpack Importer (`FTBImporter_Playnite`)**:
   - Automatically discovers FTB modpacks from local app settings and custom instance paths.
   - Imports high-res modpack branding logos.
   - Provides direct hover-to-play automated 1-click launch.

### Links
- **Source Repository**: https://github.com/gokublacko7/playnite-minecraft-modpacks
- **Releases**: https://github.com/gokublacko7/playnite-minecraft-modpacks/releases